### PR TITLE
feat: génération de noms descriptifs par l'IA

### DIFF
--- a/backend/schemas/clothing_analysis.py
+++ b/backend/schemas/clothing_analysis.py
@@ -19,6 +19,7 @@ class PieceAttributes(BaseModel):
 class ClothingPiece(BaseModel):
     piece_id: UUID
     piece_type: str  # tshirt, shirt, blazer, pants, etc.
+    name: str  # Nom descriptif généré par l'IA (ex: "Chemise blanche à col italien")
     attributes: PieceAttributes
     style_tags: List[str]
     occasion_tags: List[str]

--- a/backend/services/clothing_analyzer.py
+++ b/backend/services/clothing_analyzer.py
@@ -113,6 +113,7 @@ Retourne ce JSON EXACT :
   "pieces": [
     {
       "piece_type": "[type exact de la pièce]",
+      "name": "[nom descriptif et accrocheur en français, ex: 'Chemise blanche élégante à col italien', 'T-shirt graphique oversize tendance']",
       "attributes": {
         "colors": {
           "primary": ["couleur1"],
@@ -139,6 +140,7 @@ Retourne ce JSON EXACT :
   "pieces": [
     {
       "piece_type": "[type exact de la pièce 1]",
+      "name": "[nom descriptif et accrocheur en français]",
       "attributes": {
         "colors": {
           "primary": ["couleur1"],
@@ -155,6 +157,7 @@ Retourne ce JSON EXACT :
     },
     {
       "piece_type": "[type exact de la pièce 2]",
+      "name": "[nom descriptif et accrocheur en français]",
       "attributes": {
         "colors": {
           "primary": ["couleur1"],
@@ -192,6 +195,7 @@ Retourne ce JSON EXACT :
             piece = ClothingPiece(
                 piece_id=uuid.uuid4(),  # UUID généré côté serveur
                 piece_type=piece_data["piece_type"],
+                name=piece_data.get("name", piece_data["piece_type"]),  # Utilise le type si pas de nom
                 attributes=PieceAttributes(**piece_data["attributes"]),
                 style_tags=piece_data["style_tags"],
                 occasion_tags=piece_data["occasion_tags"],
@@ -212,6 +216,7 @@ Retourne ce JSON EXACT :
             piece = ClothingPiece(
                 piece_id=uuid.uuid4(),  # UUID généré côté serveur
                 piece_type=piece_data["piece_type"],
+                name=piece_data.get("name", piece_data["piece_type"]),  # Utilise le type si pas de nom
                 attributes=PieceAttributes(**piece_data["attributes"]),
                 style_tags=piece_data["style_tags"],
                 occasion_tags=piece_data["occasion_tags"],

--- a/backend/services/wardrobe_service.py
+++ b/backend/services/wardrobe_service.py
@@ -16,8 +16,8 @@ class WardrobeService:
         start_time = time.time()
         piece = piece_data.pieces[0]  # Une pièce unique a toujours exactement 1 pièce
         
-        # Créer le nom de la pièce (sans la couleur)
-        piece_name = piece.piece_type
+        # Utiliser le nom généré par l'IA ou fallback sur piece_type
+        piece_name = piece.name if hasattr(piece, 'name') and piece.name else piece.piece_type
         
         # Créer la pièce
         db_piece = ClothingItem(
@@ -94,8 +94,8 @@ class WardrobeService:
             ).first()
             
             if not existing_piece:
-                # Créer le nom de la pièce (sans la couleur)
-                piece_name = piece.piece_type
+                # Utiliser le nom généré par l'IA ou fallback sur piece_type
+                piece_name = piece.name if hasattr(piece, 'name') and piece.name else piece.piece_type
                 
                 # Créer la nouvelle pièce
                 db_piece = ClothingItem(

--- a/src/features/outfit-analysis/components/ClothingDetailView.js
+++ b/src/features/outfit-analysis/components/ClothingDetailView.js
@@ -136,11 +136,12 @@ export default function ClothingDetailView({ route, navigation }) {
     return (
       <>
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Type de vêtement</Text>
+          <Text style={styles.sectionTitle}>Description</Text>
           <View style={styles.infoCard}>
-            <Text style={styles.largeText}>{translateTerm(piece.piece_type || item.category || item.name)}</Text>
+            <Text style={styles.largeText}>{piece.name || item.name || translateTerm(piece.piece_type || item.category)}</Text>
+            <Text style={styles.itemType}>Type: {translateTerm(piece.piece_type || item.category)}</Text>
             {item.brand && (
-              <Text style={styles.itemBrand}>{item.brand}</Text>
+              <Text style={styles.itemBrand}>Marque: {item.brand}</Text>
             )}
           </View>
         </View>
@@ -521,6 +522,12 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginTop: 4,
     fontStyle: 'italic',
+  },
+  itemType: {
+    fontSize: 16,
+    color: '#6b7280',
+    textAlign: 'center',
+    marginTop: 8,
   },
   infoRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- ✨ L'IA génère maintenant des noms descriptifs en français pour chaque vêtement
- 📝 Les noms sont affichés de manière prominente dans le frontend
- ✏️ Les utilisateurs peuvent modifier le nom via l'éditeur d'attributs

## Changements

### Backend
- Ajout du champ `name` dans le schéma `ClothingPiece`
- Modification du prompt GPT-4 pour générer des noms descriptifs et accrocheurs
- Le `WardrobeService` utilise le nom généré ou fait un fallback sur `piece_type`

### Frontend  
- `ClothingDetailView` affiche le nom généré en grand et le type en sous-titre
- `WardrobeScreen` et `ItemCard` affichent déjà le nom
- `ItemAttributesEditor` permet de modifier le nom

## Exemples de noms générés
- "Chemise blanche élégante à col italien"
- "T-shirt graphique oversize tendance"
- "Jean slim bleu foncé délavé"
- "Robe d'été fleurie légère"

## Test plan
- [x] Analyser une pièce et vérifier que l'IA génère un nom
- [x] Vérifier que le nom s'affiche dans la vue détaillée
- [x] Vérifier que le nom s'affiche dans la garde-robe
- [x] Tester la modification du nom via l'éditeur
- [x] Vérifier le fallback sur piece_type si pas de nom

🤖 Generated with [Claude Code](https://claude.ai/code)